### PR TITLE
feat: Check for the existence of a build script and use that if it exists

### DIFF
--- a/editor-extensions/vscode/server/src/server.ts
+++ b/editor-extensions/vscode/server/src/server.ts
@@ -110,7 +110,6 @@ interface Dictionary<T> {
 // The workspace folder this server is operating on
 let workspaceFolder: string | null;
 
-
 // store lenses per document by uri
 let documentLenses: Map<string, LSP_Lens[]> = new Map();
 


### PR DESCRIPTION
When calling Grain to compile for error checking or formatting, look for the existence of a build script and run that instead of calling Grain directly.  This will ensure the compiler uses the same flags when compiling under the LSP