### PR TITLE
fix: Fix the build issue

### DIFF
--- a/editor-extensions/vscode/server/src/server.ts
+++ b/editor-extensions/vscode/server/src/server.ts
@@ -30,7 +30,7 @@ import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 
-const buildScriptPath = "script/grainfind.js";
+let buildScriptPath = "script/grainfind.js";
 
 const isWindows = /^win32/.test(process.platform);
 // Not sure if this can technically change between VSCode restarts. Even if it does,


### PR DESCRIPTION
Left a const instead of a let when we rolled back from the watcher version