### PR TITLE
feat(vscode): Add run button

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -28,10 +28,24 @@
   ],
   "main": "./out/extension",
   "contributes": {
+    "menus": {
+      "editor/title/run": [
+        {
+          "command": "grain.runEditorFile",
+          "when": "resourceLangId == grain",
+          "group": "navigation@1"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "grain.restart",
         "title": "Grain: Restart Language Server"
+      },
+      {
+        "command": "grain.runEditorFile",
+        "title": "Grain: Run File",
+        "icon": "$(play)"
       }
     ],
     "languages": [
@@ -88,6 +102,12 @@
           "scope": "resource",
           "type": "string",
           "description": "Absolute path to the grain CLI (detected in PATH if not specified)"
+        },
+        "grain.runCommandLayout": {
+          "scope": "resource",
+          "type": "string",
+          "default": "${cliPath} ${activeFile} ${cliFlags}",
+          "description": "The layout of the run command"
         },
         "grain.enableLSP": {
           "scope": "resource",


### PR DESCRIPTION
This pr adds a run current file button with a corresponding configuration and command.
![Screenshot 2024-10-24 at 3 00 31 PM](https://github.com/user-attachments/assets/910cd887-eadd-4925-9a36-eab10cef991c)
It currently uses the `runCommandLayout` configuration to build a pattern and then opens the terminal with the run command when pressed.

Closes: #167 